### PR TITLE
Dockerfile:  work in /app instead of /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM elixir:1.6
+# work in /app instead of /
+RUN mkdir -p /app
+WORKDIR /app
+
 RUN mix local.hex --force
 RUN mix local.rebar --force
 ADD . .


### PR DESCRIPTION
tested via local build.

builds properly, and executes successfully with latest postgres image